### PR TITLE
Add GitHub Actions workflows for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+name: CI
+on:
+  pull_request:
+
+jobs:
+  verify:
+    uses: ./.github/workflows/verify.yml # Call common verification workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+jobs:
+  verify:
+    uses: ./.github/workflows/verify.yml # Call common verification workflow
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Publish package
+        run: deno publish

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,16 @@
+name: Verify
+on:
+  workflow_call: # Can be called from other workflows
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Check types
+        run: deno check src/**/*.ts
+      - name: Lint code
+        run: deno lint

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ A command-line tool that provides a unified interface for running scripts across
 
 ## Features
 
-- Automatic project type detection
+- Automatic project type detection (npm, yarn, pnpm, bun, deno)
 - Interactive script selection UI
 - Script selection history caching
-- Silent mode to suppress extra output
-- Support for multiple package managers (npm, yarn, pnpm, bun, deno)
 
 ## Installation
 
@@ -64,9 +62,6 @@ uni-run --list
 ```bash
 # Run in development mode
 deno task dev
-
-# Run tests
-deno task test
 
 # Build binary
 deno task compile

--- a/deno.lock
+++ b/deno.lock
@@ -12,6 +12,7 @@
     "jsr:@std/encoding@~1.0.5": "1.0.10",
     "jsr:@std/fmt@~1.0.2": "1.0.7",
     "jsr:@std/fs@^1.0.17": "1.0.17",
+    "jsr:@std/io@~0.224.9": "0.224.9",
     "jsr:@std/path@^1.0.9": "1.0.9",
     "jsr:@std/path@~1.0.6": "1.0.9",
     "jsr:@std/text@~1.0.7": "1.0.13"
@@ -21,7 +22,8 @@
       "integrity": "f71c921cce224c13d322e5cedba4f38e8f7354c7d855c9cb22729362a53f25aa",
       "dependencies": [
         "jsr:@cliffy/internal",
-        "jsr:@std/encoding"
+        "jsr:@std/encoding",
+        "jsr:@std/io"
       ]
     },
     "@cliffy/command@1.0.0-rc.7": {
@@ -54,6 +56,7 @@
         "jsr:@cliffy/keycode",
         "jsr:@std/assert",
         "jsr:@std/fmt",
+        "jsr:@std/io",
         "jsr:@std/path@~1.0.6",
         "jsr:@std/text"
       ]
@@ -78,6 +81,9 @@
       "dependencies": [
         "jsr:@std/path@^1.0.9"
       ]
+    },
+    "@std/io@0.224.9": {
+      "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3"
     },
     "@std/path@1.0.9": {
       "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"


### PR DESCRIPTION
This PR adds GitHub Actions workflows for CI/CD:

- `verify.yml`: Reusable workflow for type checking and linting
- `ci.yml`: Runs verification on PRs
- `publish.yml`: Runs verification and publishes package to JSR on push to main or tag creation

The workflows use OIDC authentication for JSR publishing and setup-deno@v2 for Deno v2 installation.