### PR TITLE
Improve permission settings with strict restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,24 @@ A command-line tool that provides a unified interface for running scripts across
 ### Install from JSR
 
 ```bash
-deno install -g -A -n uni-run jsr:@miyaoka/uni-run/cli
+deno install -g -n uni-run \
+  --allow-read=.,$HOME/.cache/uni-run \
+  --allow-write=$HOME/.cache/uni-run \
+  --allow-env=HOME,USERPROFILE \
+  --allow-run=npm,yarn,pnpm,bun,deno \
+  jsr:@miyaoka/uni-run/cli
 ```
+
+Permissions are restricted for better security:
+
+- `--allow-read=.,$HOME/.cache/uni-run`: Only read from current directory and cache
+  - Required to detect project type and read stored preferences
+- `--allow-write=$HOME/.cache/uni-run`: Only write to cache directory
+  - Required to save script selection history
+- `--allow-env=HOME,USERPROFILE`: Only access specific environment variables
+  - Required to locate user's home directory for cache
+- `--allow-run=npm,yarn,pnpm,bun,deno`: Only run specific package managers
+  - Required to execute scripts with the appropriate package manager
 
 ### Uninstall
 

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -2,7 +2,12 @@ import { join } from "@std/path";
 import { exists, ensureDir } from "@std/fs";
 
 // Cache directory settings
-const HOME_DIR = Deno.env.get("HOME") || Deno.env.get("USERPROFILE") || "~";
+const HOME_DIR = Deno.env.get("HOME") || Deno.env.get("USERPROFILE");
+if (!HOME_DIR) {
+  throw new Error(
+    "HOME or USERPROFILE environment variable must be set to use cache feature"
+  );
+}
 const CACHE_DIR = join(HOME_DIR, ".cache", "uni-run");
 const CACHE_FILE = join(CACHE_DIR, "cache.json");
 


### PR DESCRIPTION
# Strict Permission Settings

This PR improves the installation permission settings to be more explicit and secure:

## Changes

### 1. README Update
- Changed tilde notation (`~/.cache/uni-run`) to environment variable notation (`$HOME/.cache/uni-run`)
- Added detailed explanations for each required permission

### 2. Cache Handling Improvement
- Removed the fallback value `~` from the `HOME_DIR` variable in `cache.ts`
- Added explicit error handling when environment variables don't exist

## Benefits

- Enhanced security through stricter permission specifications
- Maintained cross-platform compatibility with explicit environment variable paths
- Improved user experience with appropriate error messages