### PR TITLE
Fix CLI args handling and improve usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,13 @@ rm -rf $HOME/.cache/uni-run
 # Detect project type and select script interactively
 uni-run
 
-# List available scripts
-uni-run --list
+# Run a specific script
+uni-run dev
+
+# Run a script with arguments (using -- separator)
+uni-run test -- --watch
+uni-run build -- --mode production
+uni-run start -- --port 3000
 ```
 
 ## Supported Package Managers

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@miyaoka/uni-run",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "Universal script runner for npm, yarn, pnpm, bun, and deno projects",
   "exports": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,11 +16,17 @@ const VERSION = denoJson.version;
 const cli = new Command()
   .name("uni-run")
   .version(VERSION)
+  .versionOption("-v, --version", "Show version information")
   .description(
     "Universal script runner for npm, yarn, pnpm, bun, and deno projects"
   )
+  .usage("[options] [script] [--args]")
   .arguments("[...args:string]")
   .option("-l, --list", "List available scripts")
+  .example("Interactive mode", "uni-run")
+  .example("Run a specific script", "uni-run dev")
+  .example("Run with arguments", "uni-run test -- --watch")
+  .example("Pass build flags", "uni-run build -- --mode production")
   .action(async function (options, ...args: Array<string>) {
     // Extract script name from args (safely)
     const script = args.length > 0 ? args[0] : undefined;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,11 @@ import denoJson from "../deno.json" with { type: "json" };
 
 const VERSION = denoJson.version;
 
+// Example (for uni-run --list test -- --watch):
+//   Options:           { list: true }      # Command options
+//   Arguments:         ["test"]            # Regular arguments (script name)
+//   Literal arguments: ["--watch"]         # Arguments after "--" (passed to script)
+
 // Define main command
 const cli = new Command()
   .name("uni-run")
@@ -14,10 +19,11 @@ const cli = new Command()
   .description(
     "Universal script runner for npm, yarn, pnpm, bun, and deno projects"
   )
-  .arguments("[command...:string]")
+  .arguments("[...args:string]")
   .option("-l, --list", "List available scripts")
-  .action(async (options, command) => {
-    const [script, ...args] = command || [];
+  .action(async function (options, ...args: Array<string>) {
+    // Extract script name from args (safely)
+    const script = args.length > 0 ? args[0] : undefined;
     const cwd = Deno.cwd();
     const projectType = await detectProjectType(cwd);
 
@@ -86,8 +92,8 @@ const cli = new Command()
         Deno.exit(1);
       }
 
-      // Run the script
-      await runner.runScript(script, args);
+      // Run the script with literal args
+      await runner.runScript(script, this.getLiteralArgs());
     }
   });
 

--- a/src/runners/bun.ts
+++ b/src/runners/bun.ts
@@ -4,14 +4,14 @@ import { executeCommand } from "../utils.ts";
 import type { Runner, Script } from "../types.ts";
 
 /**
- * Bunプロジェクト用スクリプトランナーを作成
+ * Create script runner for Bun projects
  *
- * @param cwd 現在の作業ディレクトリ
- * @returns スクリプトランナーオブジェクト
+ * @param cwd Current working directory
+ * @returns Script runner object
  */
 export function createBunRunner(cwd: string): Runner {
   /**
-   * 利用可能なスクリプト一覧を取得
+   * Get list of available scripts
    */
   async function getScripts(): Promise<Script[]> {
     const packageJsonPath = join(cwd, "package.json");
@@ -36,7 +36,7 @@ export function createBunRunner(cwd: string): Runner {
   }
 
   /**
-   * 指定されたスクリプトが存在するか確認
+   * Check if the specified script exists
    */
   async function hasScript(name: string): Promise<boolean> {
     const scripts = await getScripts();
@@ -44,26 +44,24 @@ export function createBunRunner(cwd: string): Runner {
   }
 
   /**
-   * 実行コマンド文字列を取得
-   */
-  function getCommandString(name: string): string {
-    return `bun run ${name}`;
-  }
-
-  /**
-   * スクリプトを実行
+   * Run script
    */
   async function runScript(name: string, args: string[] = []): Promise<void> {
-    // --silentフラグを追加して余分な出力を抑制
-    const cmd = ["bun", "run", "--silent", name, ...args];
+    // Add --silent flag to suppress extra output
+    const cmd = ["bun", "run", "--silent", name];
+
+    // Add -- separator before script arguments if any exist
+    if (args.length > 0) {
+      cmd.push("--", ...args);
+    }
+
     await executeCommand(cmd, cwd);
   }
 
-  // スクリプトランナーオブジェクトを返す
+  // Return script runner object
   return {
     getScripts,
     hasScript,
-    getCommandString,
     runScript,
   };
 }

--- a/src/runners/deno.ts
+++ b/src/runners/deno.ts
@@ -4,17 +4,17 @@ import { executeCommand } from "../utils.ts";
 import type { Runner, Script } from "../types.ts";
 
 /**
- * Denoプロジェクト用スクリプトランナーを作成
+ * Create script runner for Deno projects
  *
- * @param cwd 現在の作業ディレクトリ
- * @returns スクリプトランナーオブジェクト
+ * @param cwd Current working directory
+ * @returns Script runner object
  */
 export function createDenoRunner(cwd: string): Runner {
   /**
-   * 利用可能なスクリプト一覧を取得
+   * Get list of available scripts
    */
   async function getScripts(): Promise<Script[]> {
-    // deno.json または deno.jsonc を探す
+    // Look for deno.json or deno.jsonc
     let configPath = join(cwd, "deno.json");
     let exists1 = await exists(configPath);
 
@@ -43,7 +43,7 @@ export function createDenoRunner(cwd: string): Runner {
   }
 
   /**
-   * 指定されたスクリプトが存在するか確認
+   * Check if the specified script exists
    */
   async function hasScript(name: string): Promise<boolean> {
     const scripts = await getScripts();
@@ -51,26 +51,24 @@ export function createDenoRunner(cwd: string): Runner {
   }
 
   /**
-   * 実行コマンド文字列を取得
-   */
-  function getCommandString(name: string): string {
-    return `deno task ${name}`;
-  }
-
-  /**
-   * スクリプトを実行
+   * Run script
    */
   async function runScript(name: string, args: string[] = []): Promise<void> {
-    // --quietフラグを追加して余分な出力を抑制
-    const cmd = ["deno", "task", "--quiet", name, ...args];
+    // Add --quiet flag to suppress extra output
+    const cmd = ["deno", "task", "--quiet", name];
+
+    // Add arguments directly (Deno tasks don't use -- separator)
+    if (args.length > 0) {
+      cmd.push(...args);
+    }
+
     await executeCommand(cmd, cwd);
   }
 
-  // スクリプトランナーオブジェクトを返す
+  // Return script runner object
   return {
     getScripts,
     hasScript,
-    getCommandString,
     runScript,
   };
 }

--- a/src/runners/npm.ts
+++ b/src/runners/npm.ts
@@ -44,18 +44,17 @@ export function createNpmRunner(cwd: string): Runner {
   }
 
   /**
-   * Get command string for execution
-   */
-  function getCommandString(name: string): string {
-    return `npm run ${name}`;
-  }
-
-  /**
    * Run script
    */
   async function runScript(name: string, args: string[] = []): Promise<void> {
     // Add --silent flag to suppress extra output
-    const cmd = ["npm", "run", "--silent", name, ...args];
+    const cmd = ["npm", "run", "--silent", name];
+
+    // Add -- separator before script arguments if any exist
+    if (args.length > 0) {
+      cmd.push("--", ...args);
+    }
+
     await executeCommand(cmd, cwd);
   }
 
@@ -63,7 +62,6 @@ export function createNpmRunner(cwd: string): Runner {
   return {
     getScripts,
     hasScript,
-    getCommandString,
     runScript,
   };
 }

--- a/src/runners/pnpm.ts
+++ b/src/runners/pnpm.ts
@@ -4,14 +4,14 @@ import { executeCommand } from "../utils.ts";
 import type { Runner, Script } from "../types.ts";
 
 /**
- * pnpmプロジェクト用スクリプトランナーを作成
+ * Create script runner for pnpm projects
  *
- * @param cwd 現在の作業ディレクトリ
- * @returns スクリプトランナーオブジェクト
+ * @param cwd Current working directory
+ * @returns Script runner object
  */
 export function createPnpmRunner(cwd: string): Runner {
   /**
-   * 利用可能なスクリプト一覧を取得
+   * Get list of available scripts
    */
   async function getScripts(): Promise<Script[]> {
     const packageJsonPath = join(cwd, "package.json");
@@ -36,7 +36,7 @@ export function createPnpmRunner(cwd: string): Runner {
   }
 
   /**
-   * 指定されたスクリプトが存在するか確認
+   * Check if the specified script exists
    */
   async function hasScript(name: string): Promise<boolean> {
     const scripts = await getScripts();
@@ -44,26 +44,24 @@ export function createPnpmRunner(cwd: string): Runner {
   }
 
   /**
-   * 実行コマンド文字列を取得
-   */
-  function getCommandString(name: string): string {
-    return `pnpm run ${name}`;
-  }
-
-  /**
-   * スクリプトを実行
+   * Run script
    */
   async function runScript(name: string, args: string[] = []): Promise<void> {
-    // --silentフラグを追加して余分な出力を抑制
-    const cmd = ["pnpm", "run", "--silent", name, ...args];
+    // Add --silent flag to suppress extra output
+    const cmd = ["pnpm", "run", "--silent", name];
+
+    // Add arguments directly (PNPM handles differently than npm)
+    if (args.length > 0) {
+      cmd.push(...args);
+    }
+
     await executeCommand(cmd, cwd);
   }
 
-  // スクリプトランナーオブジェクトを返す
+  // Return script runner object
   return {
     getScripts,
     hasScript,
-    getCommandString,
     runScript,
   };
 }

--- a/src/runners/yarn.ts
+++ b/src/runners/yarn.ts
@@ -44,18 +44,17 @@ export function createYarnRunner(cwd: string): Runner {
   }
 
   /**
-   * Get command string for execution
-   */
-  function getCommandString(name: string): string {
-    return `yarn ${name}`;
-  }
-
-  /**
    * Run script
    */
   async function runScript(name: string, args: string[] = []): Promise<void> {
     // Add --silent flag to suppress extra output
-    const cmd = ["yarn", "--silent", name, ...args];
+    const cmd = ["yarn", "run", "--silent", name];
+
+    // Add arguments directly (Yarn 1.0+ doesn't require -- separator)
+    if (args.length > 0) {
+      cmd.push(...args);
+    }
+
     await executeCommand(cmd, cwd);
   }
 
@@ -63,7 +62,6 @@ export function createYarnRunner(cwd: string): Runner {
   return {
     getScripts,
     hasScript,
-    getCommandString,
     runScript,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,11 +26,6 @@ export interface Runner {
   hasScript(name: string): Promise<boolean>;
 
   /**
-   * Get command string for execution
-   */
-  getCommandString(name: string): string;
-
-  /**
    * Run script
    */
   runScript(name: string, args: string[]): Promise<void>;

--- a/test/bun-pkg/package.json
+++ b/test/bun-pkg/package.json
@@ -6,6 +6,8 @@
     "start": "echo 'Starting bun project'",
     "build": "echo 'Building bun project'",
     "test": "echo 'Testing bun project'",
-    "long-script-name": "echo 'This is a script with a long name'"
+    "long-script-name": "echo 'This is a script with a long name'",
+    "args": "echo 'Received args:' $*",
+    "cal": "cal"
   }
 }

--- a/test/deno-pkg/deno.json
+++ b/test/deno-pkg/deno.json
@@ -8,6 +8,7 @@
     "build": "echo 'Building deno project'",
     "test": "echo 'Testing deno project'",
     "long-script-name": "echo 'This is a script with a long name'",
-    "args": "echo 'Received args:' $*"
+    "args": "echo 'Received args:' $1 $2 $3 $4 $5",
+    "cal": "cal"
   }
 }

--- a/test/npm-pkg/package.json
+++ b/test/npm-pkg/package.json
@@ -7,6 +7,7 @@
     "build": "echo 'Building npm project'",
     "test": "echo 'Testing npm project'",
     "long-script-name": "echo 'This is a script with a long name'",
-    "args": "echo 'Received args:' $*"
+    "args": "echo 'Received args:' $*",
+    "cal": "cal"
   }
 }

--- a/test/pnpm-pkg/package.json
+++ b/test/pnpm-pkg/package.json
@@ -7,6 +7,7 @@
     "build": "echo 'Building pnpm project'",
     "test": "echo 'Testing pnpm project'",
     "long-script-name": "echo 'This is a script with a long name'",
-    "args": "echo 'Received args:' $*"
+    "args": "echo 'Received args:' $*",
+    "cal": "cal"
   }
 }

--- a/test/yarn-pkg/package.json
+++ b/test/yarn-pkg/package.json
@@ -7,7 +7,8 @@
     "build": "echo 'Building yarn project'",
     "test": "echo 'Testing yarn project'",
     "long-script-name": "echo 'This is a script with a long name'",
-    "args": "echo 'Received args:' $*"
+    "args": "echo 'Received args:' $*",
+    "cal": "cal"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Changes

- Fix argument handling for different package managers:
  - npm/bun: Keep -- separator as required
  - yarn/pnpm/deno: Remove -- separator for proper argument passing
- Remove debugging console.log statements
- Remove unused getCommandString method
- Add cal script to test packages for better argument verification
- Update CLI help with more useful examples and format
- Improve usage documentation in README
- Bump version to 0.2.0