### PR TITLE
Feature: Display script command in selection menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.3.0] - 2025-04-30
+
+### Added
+
+- Enhanced interactive mode with improved script display
+- Scripts now show their command content in the selection menu
+
+### Changed
+
+- Improved visual distinction between script names and commands
+
+## [0.2.0] - 2025-04-29
+
+### Added
+
+- Support for passing arguments to scripts
+
+### Changed
+
+- Improved CLI argument handling for different package managers
+- Better command-line help with examples
+
+## [0.1.0] - 2025-04-01
+
+### Added
+
+- Initial release
+- Support for npm, yarn, pnpm, bun, and deno projects
+- Interactive script selection UI
+- Script selection history caching

--- a/README.md
+++ b/README.md
@@ -39,11 +39,9 @@ Permissions are restricted for better security:
 - `--allow-run=npm,yarn,pnpm,bun,deno`: Only run specific package managers
   - Required to execute scripts with the appropriate package manager
 
-### What's new in v0.2.0
+### Recent Updates
 
-- Improved CLI argument handling for different package managers
-- Better command-line help with examples (`uni-run -h`)
-- Support for passing arguments to scripts (`uni-run test -- --watch`)
+See [CHANGELOG.md](./CHANGELOG.md) for detailed version history and updates.
 
 ### Uninstall
 

--- a/deno.json
+++ b/deno.json
@@ -29,6 +29,7 @@
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.7",
+    "@std/fmt": "jsr:@std/fmt@^1.0.7",
     "@std/fs": "jsr:@std/fs@^1.0.17",
     "@std/path": "jsr:@std/path@^1.0.9"
   }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@miyaoka/uni-run",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "Universal script runner for npm, yarn, pnpm, bun, and deno projects",
   "exports": {

--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@std/assert@~1.0.6": "1.0.13",
     "jsr:@std/encoding@~1.0.5": "1.0.10",
+    "jsr:@std/fmt@^1.0.7": "1.0.7",
     "jsr:@std/fmt@~1.0.2": "1.0.7",
     "jsr:@std/fs@^1.0.17": "1.0.17",
     "jsr:@std/io@~0.224.9": "0.224.9",
@@ -32,7 +33,7 @@
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal",
         "jsr:@cliffy/table",
-        "jsr:@std/fmt",
+        "jsr:@std/fmt@~1.0.2",
         "jsr:@std/text"
       ]
     },
@@ -55,7 +56,7 @@
         "jsr:@cliffy/internal",
         "jsr:@cliffy/keycode",
         "jsr:@std/assert",
-        "jsr:@std/fmt",
+        "jsr:@std/fmt@~1.0.2",
         "jsr:@std/io",
         "jsr:@std/path@~1.0.6",
         "jsr:@std/text"
@@ -64,7 +65,7 @@
     "@cliffy/table@1.0.0-rc.7": {
       "integrity": "9fdd9776eda28a0b397981c400eeb1aa36da2371b43eefe12e6ff555290e3180",
       "dependencies": [
-        "jsr:@std/fmt"
+        "jsr:@std/fmt@~1.0.2"
       ]
     },
     "@std/assert@1.0.13": {
@@ -280,6 +281,7 @@
     "dependencies": [
       "jsr:@cliffy/command@^1.0.0-rc.7",
       "jsr:@cliffy/prompt@^1.0.0-rc.7",
+      "jsr:@std/fmt@^1.0.7",
       "jsr:@std/fs@^1.0.17",
       "jsr:@std/path@^1.0.9"
     ]

--- a/src/core/interactive.ts
+++ b/src/core/interactive.ts
@@ -1,4 +1,5 @@
 import { Select } from "@cliffy/prompt";
+import { dim } from "@std/fmt/colors";
 import type { Script } from "../types.ts";
 
 /**
@@ -13,11 +14,10 @@ export async function selectScript(
   defaultScript?: string
 ): Promise<Script | null> {
   try {
-    // Create options for Cliffy's selection UI
+    // Create options for Cliffy's selection UI with formatted script names and commands
     const options = scripts.map((script) => ({
-      name: script.name,
+      name: `${script.name} ${dim(`- ${script.description}`)}`,
       value: script.name,
-      description: script.description,
     }));
 
     // Display interactive selection UI (with default value)


### PR DESCRIPTION
## Changes

- Enhanced interactive mode to display both script name and its command
- Script names are shown in white color, while commands are displayed in gray
- Added `@std/fmt` dependency for text styling
- Updated version to 0.3.0
- Added CHANGELOG.md for better version history tracking

Resolves: Display script commands in the selection menu similar to the `nr` command