### PR TITLE
Add -r flag to installation command and update version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2025-04-30
+
+### Changed
+
+- Updated installation instructions to include `-r` flag for reliable version upgrades
+
 ## [0.3.0] - 2025-04-30
 
 ### Added
@@ -24,7 +30,7 @@ All notable changes to this project will be documented in this file.
 - Improved CLI argument handling for different package managers
 - Better command-line help with examples
 
-## [0.1.0] - 2025-04-01
+## [0.1.0] - 2025-04-29
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A command-line tool that provides a unified interface for running scripts across
 ## Installation / Upgrade
 
 ```bash
-deno install -gf -n uni-run \
+deno install -grf -n uni-run \
   --allow-read=.,$HOME/.cache/uni-run \
   --allow-write=$HOME/.cache/uni-run \
   --allow-env=HOME,USERPROFILE \
@@ -26,7 +26,7 @@ deno install -gf -n uni-run \
   jsr:@miyaoka/uni-run/cli
 ```
 
-> Note: The `-f` flag forces overwriting of any existing installation. You can safely run this command for first-time installation or to upgrade to the latest version.
+> Note: The `-f` flag forces overwriting of any existing installation. The `-r` flag forces reloading all dependencies, ensuring you get the latest version. You can safely run this command for first-time installation or to upgrade to the latest version.
 
 Permissions are restricted for better security:
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@miyaoka/uni-run",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "description": "Universal script runner for npm, yarn, pnpm, bun, and deno projects",
   "exports": {


### PR DESCRIPTION
## Changes

- Updated installation instructions to include `-r` flag for reliable version upgrades
- Updated version from 0.3.0 to 0.3.1
- Added entry to CHANGELOG.md for version 0.3.1

The `-r` flag ensures users get the latest version when upgrading, by forcing Deno to reload all dependencies.