### PR TITLE
Migrate cache from filesystem to localStorage API and bump version to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3] - 2025-05-04
+
+### Changed
+
+- Migrated cache storage from filesystem to Deno's localStorage API
+- Reduced required permissions (removed `--allow-write` and `--allow-env`)
+- Simplified installation command with fewer permissions
+- Converted cache-related functions from async to sync interfaces
+
 ## [0.3.2] - 2025-04-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ scripts with the appropriate commands.
 
 ```bash
 deno install -grf -n uni-run \
-  --allow-read=.,$HOME/.cache/uni-run \
-  --allow-write=$HOME/.cache/uni-run \
-  --allow-env=HOME,USERPROFILE \
+  --allow-read=. \
   --allow-run=npm,yarn,pnpm,bun,deno \
   jsr:@miyaoka/uni-run/cli
 ```
@@ -34,12 +32,8 @@ deno install -grf -n uni-run \
 
 Permissions are restricted for better security:
 
-- `--allow-read=.,$HOME/.cache/uni-run`: Only read from current directory and cache
-  - Required to detect project type and read stored preferences
-- `--allow-write=$HOME/.cache/uni-run`: Only write to cache directory
-  - Required to save script selection history
-- `--allow-env=HOME,USERPROFILE`: Only access specific environment variables
-  - Required to locate user's home directory for cache
+- `--allow-read=.`: Only read from current directory
+  - Required to detect project type
 - `--allow-run=npm,yarn,pnpm,bun,deno`: Only run specific package managers
   - Required to execute scripts with the appropriate package manager
 
@@ -52,10 +46,6 @@ See [CHANGELOG.md](./CHANGELOG.md) for detailed version history and updates.
 ```bash
 # Remove the executable
 deno uninstall -g uni-run
-
-# Remove cache directory (optional)
-# This cache stores your command selection history
-rm -rf $HOME/.cache/uni-run
 ```
 
 ## Usage

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@miyaoka/uni-run",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "description": "Universal script runner for npm, yarn, pnpm, bun, and deno projects",
   "exports": {

--- a/deno.json
+++ b/deno.json
@@ -7,14 +7,14 @@
     "./cli": "./src/cli.ts"
   },
   "tasks": {
-    "dev": "deno run --allow-read --allow-run --allow-env --allow-write src/cli.ts",
-    "test": "deno test --allow-read --allow-run --allow-env --allow-write",
-    "compile": "deno compile --allow-read --allow-run --allow-env --allow-write -o dist/uni-run src/cli.ts",
-    "test-npm": "cd test/npm-pkg && deno run --allow-read --allow-run --allow-env --allow-write ../../src/cli.ts",
-    "test-yarn": "cd test/yarn-pkg && deno run --allow-read --allow-run --allow-env --allow-write ../../src/cli.ts",
-    "test-pnpm": "cd test/pnpm-pkg && deno run --allow-read --allow-run --allow-env --allow-write ../../src/cli.ts",
-    "test-deno": "cd test/deno-pkg && deno run --allow-read --allow-run --allow-env --allow-write ../../src/cli.ts",
-    "test-bun": "cd test/bun-pkg && deno run --allow-read --allow-run --allow-env --allow-write ../../src/cli.ts"
+    "dev": "deno run --allow-read --allow-run src/cli.ts",
+    "test": "deno test --allow-read --allow-run",
+    "compile": "deno compile --allow-read --allow-run -o dist/uni-run src/cli.ts",
+    "test-npm": "cd test/npm-pkg && deno run --allow-read --allow-run ../../src/cli.ts",
+    "test-yarn": "cd test/yarn-pkg && deno run --allow-read --allow-run ../../src/cli.ts",
+    "test-pnpm": "cd test/pnpm-pkg && deno run --allow-read --allow-run ../../src/cli.ts",
+    "test-deno": "cd test/deno-pkg && deno run --allow-read --allow-run ../../src/cli.ts",
+    "test-bun": "cd test/bun-pkg && deno run --allow-read --allow-run ../../src/cli.ts"
   },
   "fmt": {
     "indentWidth": 2,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ const cli = new Command()
       }
 
       // Get the last selected script from cache
-      const lastScript = await getLastScript(cwd);
+      const lastScript = getLastScript(cwd);
 
       // Display script selection UI (with last selected script as default)
       const selected = await selectScript(scripts, lastScript);
@@ -81,7 +81,7 @@ const cli = new Command()
       }
 
       // Save selected script to cache
-      await saveCache(cwd, selected.name);
+      saveCache(cwd, selected.name);
 
       // Run the script
       await runner.runScript(selected.name, []);


### PR DESCRIPTION
## Changes

- Changed cache storage from filesystem (`$HOME/.cache/uni-run`) to Deno's localStorage API
- Converted cache-related functions from async to sync
- Reduced required permissions (removed `--allow-write` and `--allow-env`)
- Now only requires `--allow-read=.` and `--allow-run` permissions
- Updated installation command and documentation
- Bumped version to 0.3.3
- Updated CHANGELOG with the new release

## Benefits

- Runs with fewer permissions
- Improved security by eliminating filesystem access
- No need for cache directory cleanup

## Verification

- Confirmed script selection history is properly cached and the previously selected script appears pre-selected on next launch
- Verified it works correctly with the reduced permission settings